### PR TITLE
Set XAUTHORITY env variable

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -21,4 +21,4 @@ wait_warsaw root
 setpriv --reuid=$XUID /usr/local/bin/warsaw/core
 wait_warsaw $USER
 
-setpriv --reuid=$XUID --reset-env env DISPLAY=$DISPLAY firefox -no-remote -private-window seg.bb.com.br
+setpriv --reuid=$XUID --reset-env env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY firefox -no-remote -private-window seg.bb.com.br


### PR DESCRIPTION
  Make firefox authenticate properly with the host X11 server. Without it,
firefox wouldn't open in some server configurations.